### PR TITLE
Fix for "SDK Build Tools is too low for project" on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,6 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
     repositories {
@@ -12,12 +15,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }
@@ -33,4 +36,3 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+'
 }
-  


### PR DESCRIPTION
Fixing this kind of errors - [How to permanently fix “SDK Build Tools is too low for project” error in React Native for Android](https://medium.com/@alberto.schiabel/how-to-permanently-fix-sdk-build-tools-is-too-low-for-project-error-in-react-native-for-android-1a2d245bda18) but not the same way as in the article.

If a package can figure out the right SDK and buildTools versions there is not need for the app developer to add some weird code to their build.gradle file.

When I hit the same error with this package I was curious why it didn't happen with some other packages that I'm using. It turns out they are implementing this kind of strategy to overcome this problem.

I know that this solution is also hackish but personally I prefer installing a package to not break my builds.

P.S. Thanks for this package btw! It was very useful in our application and it is the only one currently maintained! <3